### PR TITLE
Configura Prettier para aumentar a largura máxima da linha

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "trailingComma": "none",
+  "printWidth": 120,
   "plugins": [
     "prettier-plugin-apex",
     "@prettier/plugin-xml"


### PR DESCRIPTION
Adicionado o parâmetro `printWidth` ao arquivo de configuração do Prettier, definindo a largura máxima da linha para 120 caracteres. Isso permitirá uma melhor formatação e menos quebras de linha em arquivos formatados.